### PR TITLE
fix: added duplication remover in MemberService.

### DIFF
--- a/src/main/java/teamproject/aipro/domain/member/controller/MemberController.java
+++ b/src/main/java/teamproject/aipro/domain/member/controller/MemberController.java
@@ -1,10 +1,12 @@
 package teamproject.aipro.domain.member.controller;
 
 import java.security.Principal;
+import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -57,5 +59,10 @@ public class MemberController {
 	public Member getMemberInfo(Principal principal) {
 		String userid = principal.getName();
 		return memberService.findByUserId(userid);
+	}
+
+	@DeleteMapping("/remove-duplicates")
+	public List<MemberResponse> removeDuplicateUsers() {
+		return memberService.removeDuplicateUsers();
 	}
 }

--- a/src/main/java/teamproject/aipro/domain/member/repository/MemberRepository.java
+++ b/src/main/java/teamproject/aipro/domain/member/repository/MemberRepository.java
@@ -1,11 +1,18 @@
 package teamproject.aipro.domain.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import teamproject.aipro.domain.member.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-	Optional<Member> findByuserid(String id);
+	Optional<Member> findByUserid(String id);
+
+	@Query("SELECT m.userid FROM Member m GROUP BY m.userid HAVING COUNT(m.userid) > 1")
+	List<String> findDuplicateUserIds();
+
+	List<Member> findAllByUserid(String userid);
 }

--- a/src/main/java/teamproject/aipro/domain/member/service/MemberService.java
+++ b/src/main/java/teamproject/aipro/domain/member/service/MemberService.java
@@ -1,13 +1,16 @@
 package teamproject.aipro.domain.member.service;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import javax.crypto.SecretKey;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -40,7 +43,7 @@ public class MemberService {
 	}
 
 	public String login(LoginRequest request) {
-		Member member = memberRepository.findByuserid(request.getUserid())
+		Member member = memberRepository.findByUserid(request.getUserid())
 			.orElse(null);
 		if (member == null) {
 			return "Invalid id or password";
@@ -59,7 +62,7 @@ public class MemberService {
 	}
 
 	public Member findByUserId(String userId) {
-		return memberRepository.findByuserid(userId).orElse(null);
+		return memberRepository.findByUserid(userId).orElse(null);
 	}
 
 	public boolean duplicateCheck(SignupRequest request) {
@@ -68,5 +71,29 @@ public class MemberService {
 		} else {
 			return false;
 		}
+	}
+
+	@Transactional
+	public List<MemberResponse> removeDuplicateUsers() {
+		List<String> duplicateUserIds = memberRepository.findDuplicateUserIds();
+
+		List<MemberResponse> cleanedMembers = new ArrayList<>();
+		for (String userId : duplicateUserIds) {
+			List<Member> members = memberRepository.findAllByUserid(userId);
+
+			if (!members.isEmpty()) {
+				Member primaryMember = members.get(0);
+				members.remove(0);
+				memberRepository.deleteAll(members);
+
+				cleanedMembers.add(new MemberResponse(
+					primaryMember.getId(),
+					primaryMember.getUserid(),
+					primaryMember.getUsername()
+				));
+			}
+		}
+
+		return cleanedMembers;
 	}
 }


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->
잘못된 postman 테스트로 DB에 중복 ID가 들어감

## To-Be
<!-- 변경 사항 -->
중복된 member를 하나만 남기고 삭제하는 API 추가

## Check List
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## (Optional) Additional Description
